### PR TITLE
fix: search the entire string of items

### DIFF
--- a/denops/@ddu-filters/matcher_fuse.ts
+++ b/denops/@ddu-filters/matcher_fuse.ts
@@ -24,6 +24,7 @@ export class Filter extends BaseFilter<Params> {
     }
 
     const options: Fuse.IFuseOptions<DduItem> = {
+      ignoreLocation: true,
       includeMatches: true,
       isCaseSensitive: !args.sourceOptions.ignoreCase,
       keys: ["matcherKey"],


### PR DESCRIPTION
Search the entire string of items.
Due to the FUSE algorithm, only the first 60 characters are searched unless [`ignoreLocation: true`](https://fusejs.io/api/options.html#ignorelocation) is specified.

See: https://fusejs.io/concepts/scoring-theory.html#distance-threshold-and-location