### PR TITLE
feat: Add sorter and highlight converter

### DIFF
--- a/denops/@ddu-filters/converter_fuse_highlight.ts
+++ b/denops/@ddu-filters/converter_fuse_highlight.ts
@@ -1,0 +1,56 @@
+import { maybe } from "jsr:@core/unknownutil@^4.0.0";
+import {
+  BaseFilter,
+  type FilterArguments,
+} from "jsr:@shougo/ddu-vim@^10.0.0/filter";
+import type { DduItem, ItemHighlight } from "jsr:@shougo/ddu-vim@^10.0.0/types";
+import { Buffer } from "node:buffer";
+import { isItemDataLike } from "../ddu-filter-fuse/predicate.ts";
+import type { ConverterFuseHighlightParams } from "../ddu-filter-fuse/types.ts";
+
+const MATCHED_HIGHLIGHT_NAME = "ddu-filter-filter_fuse_highlight-matched";
+
+/**
+ * A Ddu Filter `filter_fuse_highlight` that highlights matched text by matches
+ * from `matcher_fuse`.
+ */
+export class Filter extends BaseFilter<ConverterFuseHighlightParams> {
+  override filter(
+    args: FilterArguments<ConverterFuseHighlightParams>,
+  ): DduItem[] {
+    const filteredItems = args.items.map((item) => {
+      const matches = maybe(item.data, isItemDataLike)?.matcher_fuse.matches;
+      if (!matches || matches.length === 0) {
+        // Skips items that are not from matcher_fuse or have no matches.
+        return item;
+      }
+
+      const display = item.display ?? item.word;
+      if (item.matcherKey !== display) {
+        // Skips items whose matcherKey is not the same as display.
+        // This is to ensure that the highlights are applied to the correct text.
+        return item;
+      }
+
+      const highlights = matches.map(([start, end]): ItemHighlight => ({
+        name: MATCHED_HIGHLIGHT_NAME,
+        hl_group: args.filterParams.highlightMatched,
+        // `col` is 1-origin byte index
+        col: 1 + Buffer.byteLength(display.slice(0, start)),
+        // `width` is byte length
+        width: Buffer.byteLength(display.slice(start, end + 1)),
+      }));
+      (item.highlights ??= []).push(...highlights);
+
+      return item;
+    });
+
+    return filteredItems;
+  }
+
+  override params(): ConverterFuseHighlightParams {
+    return {
+      highlightMatched: "Search",
+    };
+  }
+}

--- a/denops/@ddu-filters/matcher_fuse.ts
+++ b/denops/@ddu-filters/matcher_fuse.ts
@@ -1,8 +1,7 @@
 import type { Denops } from "jsr:@denops/core@^7.0.0";
 import { BaseFilter } from "jsr:@shougo/ddu-vim@^10.0.0/filter";
 import type { DduItem, SourceOptions } from "jsr:@shougo/ddu-vim@^10.0.0/types";
-// @deno-types="https://deno.land/x/fuse@v6.4.1/dist/fuse.d.ts";
-import Fuse from "https://deno.land/x/fuse@v6.4.1/dist/fuse.esm.min.js";
+import Fuse, { type IFuseOptions } from "npm:fuse.js@^7.0.0";
 
 type Params = {
   threshold: number;
@@ -20,7 +19,7 @@ export class Filter extends BaseFilter<Params> {
       return Promise.resolve(args.items);
     }
 
-    const options: Fuse.IFuseOptions<DduItem> = {
+    const options: IFuseOptions<DduItem> = {
       ignoreLocation: true,
       includeMatches: true,
       isCaseSensitive: !args.sourceOptions.ignoreCase,

--- a/denops/@ddu-filters/matcher_fuse.ts
+++ b/denops/@ddu-filters/matcher_fuse.ts
@@ -8,7 +8,7 @@ import {
 import Fuse from "https://deno.land/x/fuse@v6.4.1/dist/fuse.esm.min.js";
 
 type Params = {
-  threshold: number,
+  threshold: number;
 };
 
 export class Filter extends BaseFilter<Params> {
@@ -30,7 +30,7 @@ export class Filter extends BaseFilter<Params> {
       keys: ["matcherKey"],
       shouldSort: true,
       threshold: args.filterParams.threshold,
-    }
+    };
 
     const fuse = new Fuse<DduItem>(args.items, options);
     return Promise.resolve(fuse.search(args.input).map((r) => r.item));

--- a/denops/@ddu-filters/matcher_fuse.ts
+++ b/denops/@ddu-filters/matcher_fuse.ts
@@ -30,13 +30,14 @@ export class Filter extends BaseFilter<MatcherFuseParams> {
 
     const fuse = new Fuse<DduItem>(args.items, options);
     const items = fuse.search(args.input).map((result) => {
-      const { item, score } = result as Required<typeof result>;
+      const { item, score, matches } = result as Required<typeof result>;
       return {
         ...item,
         data: {
           ...item.data as Record<string, unknown>,
           matcher_fuse: {
             score,
+            matches: matches.flatMap((m) => m.indices),
           },
         } satisfies MatcherFuseItemData,
       };

--- a/denops/@ddu-filters/matcher_fuse.ts
+++ b/denops/@ddu-filters/matcher_fuse.ts
@@ -1,6 +1,9 @@
 import type { Denops } from "jsr:@denops/core@^7.0.0";
-import { BaseFilter } from "jsr:@shougo/ddu-vim@^10.0.0/filter";
-import type { DduItem, SourceOptions } from "jsr:@shougo/ddu-vim@^10.0.0/types";
+import {
+  BaseFilter,
+  type FilterArguments,
+} from "jsr:@shougo/ddu-vim@^10.0.0/filter";
+import type { DduItem } from "jsr:@shougo/ddu-vim@^10.0.0/types";
 import Fuse, { type IFuseOptions } from "npm:fuse.js@^7.0.0";
 
 type Params = {
@@ -8,15 +11,9 @@ type Params = {
 };
 
 export class Filter extends BaseFilter<Params> {
-  filter(args: {
-    denops: Denops;
-    sourceOptions: SourceOptions;
-    filterParams: Params;
-    input: string;
-    items: DduItem[];
-  }): Promise<DduItem[]> {
+  override filter(args: FilterArguments<Params>): DduItem[] {
     if (args.input == "") {
-      return Promise.resolve(args.items);
+      return args.items;
     }
 
     const options: IFuseOptions<DduItem> = {
@@ -29,7 +26,8 @@ export class Filter extends BaseFilter<Params> {
     };
 
     const fuse = new Fuse<DduItem>(args.items, options);
-    return Promise.resolve(fuse.search(args.input).map((r) => r.item));
+    const items = fuse.search(args.input).map((r) => r.item);
+    return items;
   }
 
   params(): Params {

--- a/denops/@ddu-filters/matcher_fuse.ts
+++ b/denops/@ddu-filters/matcher_fuse.ts
@@ -1,9 +1,6 @@
-import { Denops } from "https://deno.land/x/ddu_vim@v1.2.0/deps.ts";
-import {
-  BaseFilter,
-  DduItem,
-  SourceOptions,
-} from "https://deno.land/x/ddu_vim@v1.2.0/types.ts";
+import type { Denops } from "jsr:@denops/core@^7.0.0";
+import { BaseFilter } from "jsr:@shougo/ddu-vim@^10.0.0/filter";
+import type { DduItem, SourceOptions } from "jsr:@shougo/ddu-vim@^10.0.0/types";
 // @deno-types="https://deno.land/x/fuse@v6.4.1/dist/fuse.d.ts";
 import Fuse from "https://deno.land/x/fuse@v6.4.1/dist/fuse.esm.min.js";
 

--- a/denops/@ddu-filters/sorter_fuse.ts
+++ b/denops/@ddu-filters/sorter_fuse.ts
@@ -1,0 +1,33 @@
+import { maybe } from "jsr:@core/unknownutil@^4.0.0";
+import {
+  BaseFilter,
+  type FilterArguments,
+} from "jsr:@shougo/ddu-vim@^10.0.0/filter";
+import type { DduItem } from "jsr:@shougo/ddu-vim@^10.0.0/types";
+import { isItemDataLike } from "../ddu-filter-fuse/predicate.ts";
+import type { SorterFuseParams } from "../ddu-filter-fuse/types.ts";
+
+const COMPLETE_MISMATCH_SCORE = 1;
+
+/**
+ * A Ddu Filter `sorter_fuse` that sorts items by the score from `matcher_fuse`.
+ */
+export class Filter extends BaseFilter<SorterFuseParams> {
+  override filter(args: FilterArguments<SorterFuseParams>): DduItem[] {
+    const scoreItems = args.items.map((item) => ({
+      item,
+      score: maybe(item.data, isItemDataLike)?.matcher_fuse.score ??
+        COMPLETE_MISMATCH_SCORE,
+    }));
+
+    const sortedItems = scoreItems
+      .toSorted((a, b) => a.score - b.score)
+      .map(({ item }) => item);
+
+    return sortedItems;
+  }
+
+  override params(): SorterFuseParams {
+    return {};
+  }
+}

--- a/denops/ddu-filter-fuse/predicate.ts
+++ b/denops/ddu-filter-fuse/predicate.ts
@@ -1,0 +1,6 @@
+import { is, type Predicate } from "jsr:@core/unknownutil@^4.0.0";
+import type { MatcherFuseItemData } from "./types.ts";
+
+export const isItemDataLike = is.ObjectOf({
+  matcher_fuse: is.Unknown,
+}) as Predicate<MatcherFuseItemData>;

--- a/denops/ddu-filter-fuse/types.ts
+++ b/denops/ddu-filter-fuse/types.ts
@@ -19,6 +19,18 @@ export type MatcherFuseParams = {
 export type SorterFuseParams = Record<string, never>;
 
 /**
+ * Type definitions for the `converter_fuse_highlight` Ddu filter.
+ */
+export type ConverterFuseHighlightParams = {
+  /**
+   * The highlight group name to highlight matched text.
+   *
+   * @default "Search"
+   */
+  highlightMatched: string;
+};
+
+/**
  * Type definitions for the `matcher_fuse` Ddu item data.
  */
 export interface MatcherFuseItemData {
@@ -33,6 +45,11 @@ export interface MatcherFuseItemData {
      * @see https://fusejs.io/api/options.html#includescore
      */
     score: number;
+
+    /**
+     * An array of match positions.
+     */
+    matches: Match[];
   };
 }
 

--- a/denops/ddu-filter-fuse/types.ts
+++ b/denops/ddu-filter-fuse/types.ts
@@ -1,0 +1,43 @@
+/**
+ * Type definitions for the `matcher_fuse` Ddu filter.
+ */
+export type MatcherFuseParams = {
+  /**
+   * At what point does the match algorithm give up. A threshold of `0.0`
+   * requires a perfect match (of both letters and location), a threshold of
+   * `1.0` would match anything.
+   *
+   * @default 0.6
+   * @see https://fusejs.io/api/options.html#threshold
+   */
+  threshold: number;
+};
+
+/**
+ * Type definitions for the `sorter_fuse` Ddu filter.
+ */
+export type SorterFuseParams = Record<string, never>;
+
+/**
+ * Type definitions for the `matcher_fuse` Ddu item data.
+ */
+export interface MatcherFuseItemData {
+  /**
+   * A namespace for storing the matching results of `matcher_fuse`.
+   */
+  matcher_fuse: {
+    /**
+     * A score of `0` indicates a perfect match, while a score of `1` indicates
+     * a complete mismatch.
+     *
+     * @see https://fusejs.io/api/options.html#includescore
+     */
+    score: number;
+  };
+}
+
+/**
+ * A match is a pair of indices representing the start and end positions.
+ * Indexing starts from 0, and both `start` and `end` are inclusive.
+ */
+export type Match = [start: number, end: number];

--- a/doc/ddu-filter-fuse.txt
+++ b/doc/ddu-filter-fuse.txt
@@ -1,24 +1,28 @@
-*ddu-filter-fuse.txt*	ddu.vim matcher that uses fuse.js
+*ddu-filter-fuse.txt*	ddu.vim matcher, sorter that uses Fuse.js
 
 Author: kuuote
 License: MIT license
 
-CONTENTS				*ddu-filter-matcher_fuse*
+					*ddu-filter-matcher_fuse*
+					*ddu-filter-sorter_fuse*
+CONTENTS				*ddu-filter-fuse*
 
-Introduction		|ddu-filter-matcher_fuse-introduction|
-Install			|ddu-filter-matcher_fuse-install|
-Examples		|ddu-filter-matcher_fuse-examples|
-Params			|ddu-filter-matcher_fuse-params|
+Introduction			|ddu-filter-fuse-introduction|
+Install				|ddu-filter-fuse-install|
+Examples			|ddu-filter-fuse-examples|
+Params				|ddu-filter-fuse-params|
+  Matcher Params		|ddu-filter-matcher_fuse-params|
+  Sorter Params			|ddu-filter-sorter_fuse-params|
 
 
 ==============================================================================
-INTRODUCTION			*ddu-filter-matcher_fuse-introduction*
+INTRODUCTION			*ddu-filter-fuse-introduction*
 
-This is |ddu-filters| matching items by fuse.js
+This is |ddu-filters| matching and sorting items by Fuse.js
 https://fusejs.io
 
 ==============================================================================
-INSTALL				*ddu-filter-matcher_fuse-install*
+INSTALL				*ddu-filter-fuse-install*
 
 Please install both "ddu.vim" and "denops.vim".
 
@@ -27,26 +31,32 @@ https://github.com/vim-denops/denops.vim
 
 
 ==============================================================================
-EXAMPLES			*ddu-filter-matcher_fuse-examples*
->
-	call ddu#custom#patch_global({
-	    \   'sourceOptions': {
-	    \     '_': {
-	    \       'matchers': ['matcher_fuse'],
+EXAMPLES			*ddu-filter-fuse-examples*
+>vim
+	call ddu#custom#patch_global(#{
+	    \   sourceOptions: #{
+	    \     _: #{
+	    \       matchers: ['matcher_fuse'],
+	    \       sorters: ['sorter_fuse'],
 	    \     },
 	    \   },
-	    \   'filterParams': {
-	    \     'matcher_fuse': {
-	    \       'threshold': 0.6,
+	    \   filterParams: #{
+	    \     matcher_fuse: #{
+	    \       threshold: 0.6,
 	    \     },
 	    \   }
 	    \ })
 <
 
 ==============================================================================
-PARAMS				*ddu-filter-matcher_fuse-params*
+PARAMS				*ddu-filter-fuse-params*
 
-description from https://fusejs.io/api/options.html
+Some descriptions from https://fusejs.io/api/options.html
+
+------------------------------------------------------------------------------
+MATCHER PARAMS			*ddu-filter-matcher_fuse-params*
+
+`matcher_fuse` has following optional parameters:
 
 			*ddu-filter-matcher_fuse-param-highlightMatched*
 threshold (float)
@@ -56,6 +66,13 @@ threshold (float)
 		a threshold of 1.0 would match anything.
 
 		Default: 0.6
+
+
+------------------------------------------------------------------------------
+SORTER PARAMS			*ddu-filter-sorter_fuse-params*
+
+`sorter_fuse` has no optional parameters:.
+
 
 ==============================================================================
 vim:tw=78:ts=8:ft=help:norl:noet:fen:noet:

--- a/doc/ddu-filter-fuse.txt
+++ b/doc/ddu-filter-fuse.txt
@@ -1,10 +1,11 @@
-*ddu-filter-fuse.txt*	ddu.vim matcher, sorter that uses Fuse.js
+*ddu-filter-fuse.txt*	ddu.vim matcher, sorter, converter that uses Fuse.js
 
 Author: kuuote
 License: MIT license
 
 					*ddu-filter-matcher_fuse*
 					*ddu-filter-sorter_fuse*
+					*ddu-filter-converter_fuse_highlight*
 CONTENTS				*ddu-filter-fuse*
 
 Introduction			|ddu-filter-fuse-introduction|
@@ -13,6 +14,7 @@ Examples			|ddu-filter-fuse-examples|
 Params				|ddu-filter-fuse-params|
   Matcher Params		|ddu-filter-matcher_fuse-params|
   Sorter Params			|ddu-filter-sorter_fuse-params|
+  Converter Highlight Params	|ddu-filter-converter_fuse_highlight-params|
 
 
 ==============================================================================
@@ -38,11 +40,15 @@ EXAMPLES			*ddu-filter-fuse-examples*
 	    \     _: #{
 	    \       matchers: ['matcher_fuse'],
 	    \       sorters: ['sorter_fuse'],
+	    \       filters: ['converter_fuse_highlight'],
 	    \     },
 	    \   },
 	    \   filterParams: #{
 	    \     matcher_fuse: #{
 	    \       threshold: 0.6,
+	    \     },
+	    \     converter_fuse_highlight: #{
+	    \       highlightMatched: 'Search',
 	    \     },
 	    \   }
 	    \ })
@@ -72,6 +78,17 @@ threshold (float)
 SORTER PARAMS			*ddu-filter-sorter_fuse-params*
 
 `sorter_fuse` has no optional parameters:.
+
+
+------------------------------------------------------------------------------
+CONVERTER HIGHLIGHT PARAMS	*ddu-filter-converter_fuse_highlight-params*
+
+`converter_fuse_highlight` has following optional parameters:
+
+highlightMatched (string)
+		The highlight group name to highlight matched text.
+
+		Default: 'Search'
 
 
 ==============================================================================


### PR DESCRIPTION
## Changes

**BREAKING!** Change behavior of the `matcher_fuse` filter:

- Sorting is no longer performed.

Because [`:help ddu-filters`](https://github.com/Shougo/ddu.vim/blob/1d5c9f11d6cdc4a8b550c3cace891e8e011cc22d/doc/ddu.txt#L1075-L1076
) says:

```
NOTE: "matchers" must not sort items.  Because later "sorters" overwrites the sort.
```

## New features

Added new filters:

- `sorter_fuse`: Sorts the matched items by scores.
- `converter_fuse_highlight`: Highlights the matched text.

These filters work together, allowing users to configure them freely.

## Other changes

- Updated `@shougo/ddu-vim` to `^10.0.0`.
- Updated `fuse.js` to `^7.0.0`.
- Documentation updated.
- Improved types.

## New setting example

```vim
call ddu#custom#patch_global(#{
    \   sourceOptions: #{
    \     _: #{
    \       matchers: ['matcher_fuse'],
    \       sorters: ['sorter_fuse'],
    \       filters: ['converter_fuse_highlight'],
    \     },
    \   },
    \   filterParams: #{
    \     matcher_fuse: #{
    \       threshold: 0.6,
    \     },
    \     converter_fuse_highlight: #{
    \       highlightMatched: 'Search',
    \     },
    \   }
    \ })
```